### PR TITLE
Add: error message test exec too low

### DIFF
--- a/scripts/gen_test.py
+++ b/scripts/gen_test.py
@@ -8,6 +8,7 @@ if len(sys.argv) != 2:
 source_code = open(sys.argv[1], 'r')
 Lines = source_code.readlines()
 test_file = []
+nb_test = 0
 
 def get_test(test, instr_addr, final = False):
     result = ""
@@ -48,6 +49,7 @@ for line in Lines:
             new_test = get_test(test, instr_addr)
             if new_test != "":
                 test_file.append(new_test)
+                nb_test += 1
     instr_addr += 4
 
 
@@ -67,6 +69,7 @@ for line in reversed(Lines):
             new_test = get_test(test, instr_addr, True)
             if new_test != "":
                 final_test_file.append(new_test)
+                nb_test += 1
     else:
         break
 
@@ -74,3 +77,5 @@ for line in reversed(Lines):
 with open('final_test.tmp', 'w') as f:
     for item in final_test_file:
         f.write("%s\n" % item)
+
+print(f"Generated {nb_test} tests")

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -32,8 +32,7 @@ run_test ()
     fi
 
     ./${SCRIPT_FOLDER}/get_bin.sh $TEST_FILE_PATH
-    python3 ./${SCRIPT_FOLDER}/gen_test.py $TEST_FILE_PATH
-
+    NB_TEST=$(python3 ./${SCRIPT_FOLDER}/gen_test.py $TEST_FILE_PATH | sed -n 's/^Generated \([[:digit:]]*\) tests$/\1/p')
 
     if [ -z $2 ]; then
         vsim -c -do "do simu.do; quit -f" >& /dev/null
@@ -41,7 +40,7 @@ run_test ()
         vsim -do "do simu.do"
     fi
 
-    print_result "$TEST_BENCH-$(basename $TEST_FILE_PATH .S)"
+    print_result "$TEST_BENCH-$(basename $TEST_FILE_PATH .S)" "$NB_TEST"
 }
 
 print_result ()
@@ -70,6 +69,10 @@ print_result ()
             echo "$line" | cut -c 6-
         fi
     done < ./transcript
+
+    if [ ! -z $2 ] && [ $2 -ne 0 ] && [ $nb_test -lt $2 ]; then
+        echo -e "\033[0;31m$BOLD"Warning:"$NORMAL\033[0m Only $BOLD$nb_test$NORMAL tests were executed, at least $BOLD$2$NORMAL were expected."
+    fi
 
     echo -e "[\033[0;34m$BOLD$1$NORMAL\033[0m]$BOLD Test: $nb_test | Passed: $NORMAL\033[0;32m$BOLD$nb_pass$NORMAL\033[0m$BOLD | Failed: $NORMAL\033[0;31m$BOLD$nb_fail$NORMAL\033[0m"
 }


### PR DESCRIPTION
Add: error message when the number of ran test is lower than the number of test present in the assembly file (the number of ran test can be superior, and in few time lower that's why it's only a warning.